### PR TITLE
query_orders_info: check that col exists in orders

### DIFF
--- a/pykrakenapi/pykrakenapi.py
+++ b/pykrakenapi/pykrakenapi.py
@@ -1897,7 +1897,7 @@ class KrakenAPI(object):
 
         Parameters
         ----------
-        txid : int
+        txid : str
             Transaction id.
 
         otp : str

--- a/pykrakenapi/pykrakenapi.py
+++ b/pykrakenapi/pykrakenapi.py
@@ -1165,7 +1165,8 @@ class KrakenAPI(object):
             del orders['descr']
             orders = pd.concat((orders, descr), axis=1)
             for col in ['closetm', 'expiretm', 'opentm', 'starttm']:
-                orders.loc[:, col] = orders[col].astype(int)
+                if col in orders:
+                    orders.loc[:, col] = orders[col].astype(int)
             for col in ['cost', 'fee', 'price', 'vol', 'vol_exec',
                         'descr_price', 'descr_price2']:
                 orders.loc[:, col] = orders[col].astype(float)


### PR DESCRIPTION
If you call `query_orders_info` on an open order then the following error below gets thrown because open orders do not have a closed time (closetm). The code in the pull request fixes this, not sure if it would be better to add the closetm column but with a null value if it doesn't exist?

```python
  File "/Users/user/program/pykrakenapi/pykrakenapi/pykrakenapi.py", line 53, in wrapper
    result = func(*args, **kwargs)
  File "/Users/user/program/pykrakenapi/pykrakenapi/pykrakenapi.py", line 100, in wrapper
    result = func(*args, **kwargs)
  File "/Users/user/program/pykrakenapi/pykrakenapi/pykrakenapi.py", line 1169, in query_orders_info
    orders.loc[:, col] = orders[col].astype(int)
  File "/Users/user/program/virtual_env/lib/python3.6/site-packages/pandas/core/frame.py", line 2685, in __getitem__
    return self._getitem_column(key)
  File "/Users/user/program/virtual_env/lib/python3.6/site-packages/pandas/core/frame.py", line 2692, in _getitem_column
    return self._get_item_cache(key)
  File "/Users/user/program/virtual_env/lib/python3.6/site-packages/pandas/core/generic.py", line 2486, in _get_item_cache
    values = self._data.get(item)
  File "/Users/user/program/virtual_env/lib/python3.6/site-packages/pandas/core/internals.py", line 4115, in get
    loc = self.items.get_loc(item)
  File "/Users/user/program/virtual_env/lib/python3.6/site-packages/pandas/core/indexes/base.py", line 3065, in get_loc
    return self._engine.get_loc(self._maybe_cast_indexer(key))
  File "pandas/_libs/index.pyx", line 140, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/index.pyx", line 162, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/hashtable_class_helper.pxi", line 1492, in pandas._libs.hashtable.PyObjectHashTable.get_item
  File "pandas/_libs/hashtable_class_helper.pxi", line 1500, in pandas._libs.hashtable.PyObjectHashTable.get_item
KeyError: 'closetm'
```
