### PR TITLE
Error fix caused by Kraken's naming system for asset pairs

### DIFF
--- a/pykrakenapi/pykrakenapi.py
+++ b/pykrakenapi/pykrakenapi.py
@@ -534,6 +534,7 @@ class KrakenAPI(object):
             raise KrakenAPIError(res['error'])
 
         # create dataframe
+        pair = list(res['result'].keys())[0]
         ohlc = pd.DataFrame(res['result'][pair])
         last = res['result']['last']
 
@@ -700,6 +701,7 @@ class KrakenAPI(object):
             raise KrakenAPIError(res['error'])
 
         # create dataframe
+        pair = list(res['result'].keys())[0]
         trades = pd.DataFrame(res['result'][pair])
 
         # last timestamp
@@ -792,6 +794,7 @@ class KrakenAPI(object):
             raise KrakenAPIError(res['error'])
 
         # create dataframe
+        pair = list(res['result'].keys())[0]
         spread = pd.DataFrame(res['result'][pair])
 
         # last timestamp


### PR DESCRIPTION
When using Kraken's REST API together with `pykrakenapi`, some trading pairs (such as the very popular `XBTUSD`) produce a KeyError, even though the pair [exists in Kraken's Asset Pair endpoint](https://api.kraken.com/0/public/AssetPairs).

For example, the following code
``` python
import krakenex
from pykrakenapi import KrakenAPI

timestamp = 1546300800000000000
pair = 'XBTUSD'

trades = k.get_recent_trades(pair=pair, since=timestamp, ascending=True)
```
results in the following error:
> File "C:\Users\Tim-Vrhn\PycharmProjects\Kraken\lib\site-packages\pykrakenapi\pykrakenapi.py", line 704, in get_recent_trades  
> trades = pd.DataFrame(res['result'][pair])  
> KeyError: 'XBTUSD'

This issue is a result of Kraken using a different name for the trading pair. In the case of `XBTUSD`, this is `XXBTZUSD`. This can be illustrated as follows:

``` python
>>> trades = api.query_public("Trades", {'pair': 'XBTUSD', 'since': 1546300800000000000, 'ascending': True})
>>> print(trades)
{'error': [], 'result': {'XXBTZUSD': [['3690.90000', '0.00400000', 1546300800.4732, 's', 'l', ''], ...
```

The error is produced when a dataframe is constructed in the `pykrakenapi.py` function that is being called:

``` python
def get_recent_trades(self, pair, since=None, ascending=False):
    ...
    ...
    # create dataframe
    trades = pd.DataFrame(res['result'][pair])
    ...
```

This issue can be fixed by changing the value for `pair` to the correct key:
``` python
def get_recent_trades(self, pair, since=None, ascending=False):
    ...
    ...
    # create dataframe
    pair = list(res['result'].keys())[0]
    trades = pd.DataFrame(res['result'][pair])
    ...
```

Where `list(res['result'].keys())[0]` equals the first key of the dictionary under the `result` key.