### PR TITLE
Add call for system status

### DIFF
--- a/pykrakenapi/pykrakenapi.py
+++ b/pykrakenapi/pykrakenapi.py
@@ -286,8 +286,8 @@ class KrakenAPI(object):
                 limit_only (existing orders are cancelable, and only new limit orders can be submitted)
                 maintenance (system is offline for maintenance)
 
-        timestamp : str
-            The timestamp in ISO 8601 yyyy-mm-ddthhmmssz format.
+        timestamp : pandas._libs.tslib.Timestamp
+            The server's datetime.
 
         Raises
         ------
@@ -311,7 +311,7 @@ class KrakenAPI(object):
 
         # extract results
         status = res['result']['status']
-        timestamp = res['result']['timestamp']
+        timestamp = pd.to_datetime(res['result']['timestamp'])
 
         return status, timestamp    
     

--- a/pykrakenapi/pykrakenapi.py
+++ b/pykrakenapi/pykrakenapi.py
@@ -596,6 +596,7 @@ class KrakenAPI(object):
             ohlc['dtime'] = pd.to_datetime(ohlc.time, unit='s')
             ohlc.sort_values('dtime', ascending=ascending, inplace=True)
             ohlc.set_index('dtime', inplace=True)
+            ohlc.index.freq = str(interval) + 'T'
 
             # dtypes
             for col in ['open', 'high', 'low', 'close', 'vwap', 'volume']:

--- a/pykrakenapi/pykrakenapi.py
+++ b/pykrakenapi/pykrakenapi.py
@@ -271,6 +271,52 @@ class KrakenAPI(object):
 
     @crl_sleep
     @callratelimiter('public')
+    def get_system_status(self):
+        """Get system status.
+
+        Return the Kraken system status.
+
+        Returns
+        -------
+        status : str
+            The systems status. Possible status values include:
+                online (operational, full trading available)
+                cancel_only (existing orders are cancelable, but new orders cannot be created)
+                post_only (existing orders are cancelable, and only new post limit orders can be submitted)
+                limit_only (existing orders are cancelable, and only new limit orders can be submitted)
+                maintenance (system is offline for maintenance)
+
+        timestamp : str
+            The timestamp in ISO 8601 yyyy-mm-ddthhmmssz format.
+
+        Raises
+        ------
+        HTTPError
+            An HTTP error occurred.
+
+        KrakenAPIError
+            A kraken.com API error occurred.
+
+        CallRateLimitError
+            The call rate limiter blocked the query.
+
+        """
+
+        # query
+        res = self.api.query_public('SystemStatus')
+
+        # check for error
+        if len(res['error']) > 0:
+            raise KrakenAPIError(res['error'])
+
+        # extract results
+        status = res['result']['status']
+        timestamp = res['result']['timestamp']
+
+        return status, timestamp    
+    
+    @crl_sleep
+    @callratelimiter('public')
     def get_asset_info(self, info=None, aclass=None, asset=None):
         """Get asset info.
 


### PR DESCRIPTION
Hello there,

I've added the `get_system_status` call to get the kraken system status. [https://api.kraken.com/0/public/SystemStatus](https://api.kraken.com/0/public/SystemStatus)

The timestamp comes as a `str` in the (ISO 8601) yyyy-mm-ddthhmmssz format.
I convert it to a `pandas.Timestamp`. Is unixtimestamp more usefull? Or should I leave the str as it is?
