### PR TITLE
Add `User Staking` endpoints

### DIFF
--- a/pykrakenapi/__init__.py
+++ b/pykrakenapi/__init__.py
@@ -72,7 +72,7 @@ from __future__ import absolute_import
 from pykrakenapi.pykrakenapi import KrakenAPI
 
 __all__ = ['KrakenAPI']
-__version__ = '0.2.3'
+__version__ = '0.2.4'
 __author__ = "Dominik Traxl <dominik.traxl@posteo.org>"
 __copyright__ = "Copyright 2017 Dominik Traxl"
 __license__ = "GNU GPL"

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="pykrakenapi",
-    version='0.2.3',
+    version='0.2.4',
     packages=find_packages(),
     author="Dominik Traxl",
     author_email="dominik.traxl@posteo.org",


### PR DESCRIPTION
This evening I decided to go and add the `User Staking` endpoints myself.

I think I've tested them all and as long as the appropriate settings are applied in the Kraken API everything seems to work. This essentially means ticking all the `Funds` options:

![image](https://user-images.githubusercontent.com/41046859/151069787-f006a0cd-1648-4a22-8590-daada85e0877.png)

Note that I've **NOT** tested the 2FA, but it's re-using the existing code so if it's working elsewhere then it should work here too?

I've tried to keep everything in the same style/format as well as returning `pd.DataFrame` objects where applicable. I also bumped the version number in the `__init__.py` and `setup.py` files.

It could be streamlined a bit combining `stake_asset` and `unstake_asset` and `get_pending_staking_transactions` and `get_staking_transactions`, but I wanted to keep it in the spirit of the API and the existing code.

The docstrings etc are mostly taken from the [Kraken REST API](https://docs.kraken.com/rest/#tag/User-Staking) documentation.

I'm happy to update it **when** you find errors :-)