### PR TITLE
Added websockets token endpoint

### DIFF
--- a/pykrakenapi/__init__.py
+++ b/pykrakenapi/__init__.py
@@ -72,7 +72,7 @@ from __future__ import absolute_import
 from pykrakenapi.pykrakenapi import KrakenAPI
 
 __all__ = ['KrakenAPI']
-__version__ = '0.2.4'
+__version__ = '0.2.5'
 __author__ = "Dominik Traxl <dominik.traxl@posteo.org>"
 __copyright__ = "Copyright 2017 Dominik Traxl"
 __license__ = "GNU GPL"

--- a/pykrakenapi/pykrakenapi.py
+++ b/pykrakenapi/pykrakenapi.py
@@ -2788,7 +2788,7 @@ class KrakenAPI(object):
         The 'Access WebSockets API' permission must be enabled for the API key
         in order to generate the authentication token.
 
-        Returns a ``dict`` of the transaction Reference ID.
+        Returns a ``dict`` of the websockets token and expriry time (secs).
 
         Parameters
         ----------

--- a/pykrakenapi/pykrakenapi.py
+++ b/pykrakenapi/pykrakenapi.py
@@ -108,7 +108,7 @@ def callratelimiter(query_type):
                             self.time_of_last_public_query = now
                             continue
 
-            # privat API, determine increment
+            # private API, determine increment
             if query_type == 'ledger/trade history':
                 incr = 2
             elif query_type == 'other':
@@ -2492,6 +2492,8 @@ class KrakenAPI(object):
             self.api_counter = 0
         self.time_of_last_query = now
 
+    @crl_sleep
+    @callratelimiter('other')
     def get_stakeable_assets(self, otp=None):
         """Get list of stakeable assets and staking details.
 
@@ -2549,6 +2551,8 @@ class KrakenAPI(object):
 
         return assets
 
+    @crl_sleep
+    @callratelimiter('other')
     def get_pending_staking_transactions(self, otp=None):
         """Get list of pending staking transactions.
 
@@ -2609,6 +2613,8 @@ class KrakenAPI(object):
 
         return transactions
 
+    @crl_sleep
+    @callratelimiter('other')
     def get_staking_transactions(self, otp=None):
         """Returns the list of 1000 recent staking transactions from past
         90 days.
@@ -2670,6 +2676,8 @@ class KrakenAPI(object):
 
         return transactions
 
+    @crl_sleep
+    @callratelimiter('other')
     def stake_asset(self, asset, amount, method, otp=None):
         """Stake an asset from your spot wallet. This operation requires an
         API key with `Withdraw funds` permission.
@@ -2719,6 +2727,8 @@ class KrakenAPI(object):
 
         return res['result']
 
+    @crl_sleep
+    @callratelimiter('other')
     def unstake_asset(self, asset, amount, otp=None):
         """Unstake an asset from your staking wallet. This operation requires
         an API key with `Withdraw funds` permission.
@@ -2759,6 +2769,57 @@ class KrakenAPI(object):
 
         # query
         res = self.api.query_private('Unstake', data=data)
+
+        # check for error
+        if len(res['error']) > 0:
+            raise KrakenAPIError(res['error'])
+
+        return res['result']
+
+    @crl_sleep
+    @callratelimiter('other')
+    def get_websockets_token(self, opt=None):
+        """An authentication token must be requested via this REST API endpoint
+        in order to connect to and authenticate with our Websockets API. The
+        token should be used within 15 minutes of creation, but it does not
+        expire once a successful Websockets connection and private subscription
+        has been made and is maintained.
+
+        The 'Access WebSockets API' permission must be enabled for the API key
+        in order to generate the authentication token.
+
+        Returns a ``dict`` of the transaction Reference ID.
+
+        Parameters
+        ----------
+        otp : str
+            Two-factor password (if two-factor enabled, otherwise not required)
+
+        Returns
+        -------
+        token: str
+            Websockets token
+        expires : int
+            Time (in seconds) after which the token expires
+
+        Raises
+        ------
+        HTTPError
+            An HTTP error occurred.
+
+        KrakenAPIError
+            A kraken.com API error occurred.
+
+        CallRateLimitError
+            The call rate limiter blocked the query.
+
+        """
+        # create data dictionary
+        data = {arg: value for arg, value in locals().items() if
+                arg != 'self' and value is not None}
+
+        # query
+        res = self.api.query_private('GetWebSocketsToken', data=data)
 
         # check for error
         if len(res['error']) > 0:

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="pykrakenapi",
-    version='0.2.4',
+    version='0.2.5',
     packages=find_packages(),
     author="Dominik Traxl",
     author_email="dominik.traxl@posteo.org",


### PR DESCRIPTION
 - Added the websockets token endpoint to generate a token for using private websockets API streams.
 - Added the call limiters to the token endpoints.

I figured the previous PR was a bit overwhelming with the trade rate limiting (plus I found a better way to manager that). This PR is nice and simple...