### PR TITLE
Fix(#80): get_recent_trades, missing id column

### DIFF
--- a/pykrakenapi/pykrakenapi.py
+++ b/pykrakenapi/pykrakenapi.py
@@ -761,7 +761,7 @@ class KrakenAPI(object):
         if not trades.empty:
 
             trades.columns = [
-                'price', 'volume', 'time', 'buy_sell', 'market_limit', 'misc'
+                'price', 'volume', 'time', 'buy_sell', 'market_limit', 'misc', 'id'
             ]
             trades.buy_sell.replace('b', 'buy', inplace=True)
             trades.buy_sell.replace('s', 'sell', inplace=True)


### PR DESCRIPTION
Answering to issue : Problems with get_recent_trades #80 It appears that the id column was missing.
Adding it to columns resolves the error