### PR TITLE
fix FurureWarning for get_recent_trades()

### DIFF
--- a/pykrakenapi/pykrakenapi.py
+++ b/pykrakenapi/pykrakenapi.py
@@ -763,10 +763,10 @@ class KrakenAPI(object):
             trades.columns = [
                 'price', 'volume', 'time', 'buy_sell', 'market_limit', 'misc', 'id'
             ]
-            trades.buy_sell.replace('b', 'buy', inplace=True)
-            trades.buy_sell.replace('s', 'sell', inplace=True)
-            trades.market_limit.replace('l', 'limit', inplace=True)
-            trades.market_limit.replace('m', 'market', inplace=True)
+            trades.replace({'buy_sell': 'b'}, 'buy', inplace=True)
+            trades.replace({'buy_sell': 's'}, 'sell', inplace=True)
+            trades.replace({'market_limit': 'l'}, 'limit', inplace=True)
+            trades.replace({'market_limit': 'm'}, 'market', inplace=True)
 
             # time
             trades['dtime'] = pd.to_datetime(trades.time, unit='s')


### PR DESCRIPTION
FutureWarning: A value is trying to be set on a copy of a DataFrame or Series through chained assignment using an inplace method. The behavior will change in pandas 3.0. This inplace method will never work because the intermediate object on which we are setting values always behaves as a copy.

For example, when doing 'df[col].method(value, inplace=True)', try using 'df.method({col: value}, inplace=True)' or df[col] = df[col].method(value) instead, to perform the operation inplace on the original object.